### PR TITLE
Error on Content-Type header with charset

### DIFF
--- a/jsonrpc2/http.go
+++ b/jsonrpc2/http.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"mime"
 	"net/http"
 	"net/rpc"
 )
@@ -67,7 +68,8 @@ func (h *httpHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		return
 	}
-	if req.Header.Get("Content-Type") != contentType || req.Header.Get("Accept") != contentType {
+	mediaType, _, _ := mime.ParseMediaType(req.Header.Get("Content-Type"))
+	if mediaType != contentType || req.Header.Get("Accept") != contentType {
 		w.WriteHeader(http.StatusUnsupportedMediaType)
 		return
 	}

--- a/jsonrpc2/http_test.go
+++ b/jsonrpc2/http_test.go
@@ -54,6 +54,7 @@ func TestHTTPServer(t *testing.T) {
 		{"POST", contentType, contentType, " ", http.StatusOK, jParse},
 		{"POST", contentType, contentType, "{", http.StatusOK, jParse},
 		{"POST", contentType, contentType, `{"jsonrpc":"2.0",`, http.StatusOK, jParse},
+		{"POST", "application/json; charset=utf-8", contentType, jSum, http.StatusOK, jRes},
 	}
 
 	ts := httptest.NewServer(jsonrpc2.HTTPHandler(nil))

--- a/jsonrpc2/http_test.go
+++ b/jsonrpc2/http_test.go
@@ -54,7 +54,7 @@ func TestHTTPServer(t *testing.T) {
 		{"POST", contentType, contentType, " ", http.StatusOK, jParse},
 		{"POST", contentType, contentType, "{", http.StatusOK, jParse},
 		{"POST", contentType, contentType, `{"jsonrpc":"2.0",`, http.StatusOK, jParse},
-		{"POST", "application/json; charset=utf-8", contentType, jSum, http.StatusOK, jRes},
+		{"POST", contentType + "; charset=utf-8", contentType, jSum, http.StatusOK, jRes},
 	}
 
 	ts := httptest.NewServer(jsonrpc2.HTTPHandler(nil))


### PR DESCRIPTION
Hi

When `Content-Type` header contains encoding type and looks like `application/json; charset=utf-8` request fails with 415 status code.
Add test to reproduce this and parse header with mime package.