### PR TITLE
fix response content type checking

### DIFF
--- a/jsonrpc2/http.go
+++ b/jsonrpc2/http.go
@@ -131,8 +131,11 @@ func (conn *httpClientConn) Write(buf []byte) (int, error) {
 			var resp *http.Response
 			resp, err = conn.doer.Do(req)
 			const maxBodySlurpSize = 32 * 1024
+
+			mediaType, _, _ := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+
 			if err != nil {
-			} else if resp.Header.Get("Content-Type") != contentType {
+			} else if mediaType != contentType {
 				err = fmt.Errorf("bad HTTP Content-Type: %s", resp.Header.Get("Content-Type"))
 			} else if resp.StatusCode == http.StatusOK {
 				conn.ready <- resp.Body

--- a/jsonrpc2/http.go
+++ b/jsonrpc2/http.go
@@ -131,26 +131,26 @@ func (conn *httpClientConn) Write(buf []byte) (int, error) {
 			var resp *http.Response
 			resp, err = conn.doer.Do(req)
 			const maxBodySlurpSize = 32 * 1024
-
-			mediaType, _, _ := mime.ParseMediaType(resp.Header.Get("Content-Type"))
-
-			if err != nil {
-			} else if mediaType != contentType {
-				err = fmt.Errorf("bad HTTP Content-Type: %s", resp.Header.Get("Content-Type"))
-			} else if resp.StatusCode == http.StatusOK {
-				conn.ready <- resp.Body
-				return
-			} else if resp.StatusCode == http.StatusNoContent || resp.StatusCode == http.StatusAccepted {
-				// Read the body if small so underlying TCP connection will be re-used.
-				// No need to check for errors: if it fails, Transport won't reuse it anyway.
-				if resp.ContentLength == -1 || resp.ContentLength <= maxBodySlurpSize {
-					io.CopyN(ioutil.Discard, resp.Body, maxBodySlurpSize)
+			
+			if err == nil {
+				mediaType, _, _ := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+				if mediaType != contentType {
+					err = fmt.Errorf("bad HTTP Content-Type: %s", resp.Header.Get("Content-Type"))
+				} else if resp.StatusCode == http.StatusOK {
+					conn.ready <- resp.Body
+					return
+				} else if resp.StatusCode == http.StatusNoContent || resp.StatusCode == http.StatusAccepted {
+					// Read the body if small so underlying TCP connection will be re-used.
+					// No need to check for errors: if it fails, Transport won't reuse it anyway.
+					if resp.ContentLength == -1 || resp.ContentLength <= maxBodySlurpSize {
+						io.CopyN(ioutil.Discard, resp.Body, maxBodySlurpSize)
+					}
+					resp.Body.Close()
+					return
+				} else {
+					err = fmt.Errorf("bad HTTP Status: %s", resp.Status)
 				}
-				resp.Body.Close()
-				return
-			} else {
-				err = fmt.Errorf("bad HTTP Status: %s", resp.Status)
-			}
+			}	
 			if resp != nil {
 				// Read the body if small so underlying TCP connection will be re-used.
 				// No need to check for errors: if it fails, Transport won't reuse it anyway.

--- a/jsonrpc2/http.go
+++ b/jsonrpc2/http.go
@@ -131,7 +131,7 @@ func (conn *httpClientConn) Write(buf []byte) (int, error) {
 			var resp *http.Response
 			resp, err = conn.doer.Do(req)
 			const maxBodySlurpSize = 32 * 1024
-			
+
 			if err == nil {
 				mediaType, _, _ := mime.ParseMediaType(resp.Header.Get("Content-Type"))
 				if mediaType != contentType {
@@ -150,7 +150,7 @@ func (conn *httpClientConn) Write(buf []byte) (int, error) {
 				} else {
 					err = fmt.Errorf("bad HTTP Status: %s", resp.Status)
 				}
-			}	
+			}
 			if resp != nil {
 				// Read the body if small so underlying TCP connection will be re-used.
 				// No need to check for errors: if it fails, Transport won't reuse it anyway.


### PR DESCRIPTION
We use `Content-Type: application/json; charset: utf-8` instead of `Content-Type: application/json` and recieve error:
```
bad HTTP Content-Type: application/json; charset: utf-8
```

The PR fix it.