### PR TITLE
Export NewClientCodec

### DIFF
--- a/jsonrpc2/client.go
+++ b/jsonrpc2/client.go
@@ -239,9 +239,7 @@ func (c Client) Notify(serviceMethod string, args interface{}) error {
 // NewClient returns a new Client to handle requests to the
 // set of services at the other end of the connection.
 func NewClient(conn io.ReadWriteCloser) *Client {
-	codec := NewClientCodec(conn)
-	client := rpc.NewClientWithCodec(codec)
-	return &Client{client, codec}
+	return NewClientWithCodec(NewClientCodec(conn))
 }
 
 // NewClientWithCodec returns a new Client using the given rpc.ClientCodec.

--- a/jsonrpc2/client.go
+++ b/jsonrpc2/client.go
@@ -223,7 +223,7 @@ func (c *clientCodec) Close() error {
 // It also provides all methods of net/rpc Client.
 type Client struct {
 	*rpc.Client
-	codec *clientCodec
+	codec rpc.ClientCodec
 }
 
 // Notify try to invoke the named function. It return error only in case
@@ -241,7 +241,13 @@ func (c Client) Notify(serviceMethod string, args interface{}) error {
 func NewClient(conn io.ReadWriteCloser) *Client {
 	codec := NewClientCodec(conn)
 	client := rpc.NewClientWithCodec(codec)
-	return &Client{client, codec.(*clientCodec)}
+	return &Client{client, codec}
+}
+
+// NewClientWithCodec returns a new Client using the given rpc.ClientCodec.
+func NewClientWithCodec(codec rpc.ClientCodec) *Client {
+	client := rpc.NewClientWithCodec(codec)
+	return &Client{client, codec}
 }
 
 // Dial connects to a JSON-RPC 2.0 server at the specified network address.

--- a/jsonrpc2/client.go
+++ b/jsonrpc2/client.go
@@ -34,8 +34,8 @@ type clientCodec struct {
 	pending map[uint64]string // map request id to method name
 }
 
-// newClientCodec returns a new rpc.ClientCodec using JSON-RPC 2.0 on conn.
-func newClientCodec(conn io.ReadWriteCloser) rpc.ClientCodec {
+// NewClientCodec returns a new rpc.ClientCodec using JSON-RPC 2.0 on conn.
+func NewClientCodec(conn io.ReadWriteCloser) rpc.ClientCodec {
 	return &clientCodec{
 		dec:     json.NewDecoder(conn),
 		enc:     json.NewEncoder(conn),
@@ -239,7 +239,7 @@ func (c Client) Notify(serviceMethod string, args interface{}) error {
 // NewClient returns a new Client to handle requests to the
 // set of services at the other end of the connection.
 func NewClient(conn io.ReadWriteCloser) *Client {
-	codec := newClientCodec(conn)
+	codec := NewClientCodec(conn)
 	client := rpc.NewClientWithCodec(codec)
 	return &Client{client, codec.(*clientCodec)}
 }


### PR DESCRIPTION
Super tiny change, but I needed to extend the functionality of your codec EVER so slightly and preferred to go this route, for now at least.  If you merge I'd love to import yours instead of my fork!

I still wanted to use this Client with Notify method.  I don't think using the interface value to store the codec affects anything at this time.