### PR TITLE
Improve response handling

### DIFF
--- a/jsonrpc2/client.go
+++ b/jsonrpc2/client.go
@@ -128,7 +128,6 @@ func fixId(raw []byte) []byte {
 	}
 
 	if id, ok := data["id"]; ok {
-		data["id"] = 0
 		if sid, ok := id.(string); ok {
 			i, _ := strconv.Atoi(sid)
 			data["id"] = i

--- a/jsonrpc2/client.go
+++ b/jsonrpc2/client.go
@@ -133,7 +133,12 @@ func (r *clientResponse) UnmarshalJSON(raw []byte) error {
 	_, okVer := o["jsonrpc"]
 	_, okID := o["id"]
 	_, okRes := o["result"]
-	_, okErr := o["error"]
+	errV, okErr := o["error"]
+	if okErr && errV == nil {
+		okErr = false
+		delete(o, "error")
+	}
+
 	if !okVer || !okID || !(okRes || okErr) || (okRes && okErr) || len(o) > 3 {
 		return errors.New("bad response: " + string(raw))
 	}


### PR DESCRIPTION
Trying to use this library to interface with the Nutshell CRM API ( https://developers.nutshell.com/#json-rpc ) and I ran into two small problems:

1. Their responses always contain an error field, but it's set to `null` if there's no error
2. Their IDs are returned as a string, not a number ( ie, `"id": "0"` or `"id":"eybe"` ).

You can see this by [going to their API explorer and hitting 'send', then checking the output](https://developers.nutshell.com/console.php#auth=none&type=json-rpc&url=api.nutshell.com/v1/json&body=%7B%22username%22%3A%22jim%40demo.nutshell.com%22%7D&method=getApiForUsername)

As far as I can tell, these are both valid in the JSON-RPC 2.0 spec.

These changes add a bit of handling for these cases. 